### PR TITLE
CryptographyClient: some progress

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -48,6 +48,7 @@ dependencies:
   '@types/nise': 1.4.0
   '@types/nock': 10.0.3
   '@types/node': 8.10.51
+  '@types/pem-jwk': 1.5.0
   '@types/priorityqueuejs': 1.0.1
   '@types/qs': 6.5.3
   '@types/query-string': 6.2.0
@@ -101,6 +102,7 @@ dependencies:
   inherits: 2.0.4
   is-buffer: 2.0.3
   jssha: 2.3.1
+  jwk-to-pem: 2.0.1
   jws: 3.2.2
   karma: 4.2.0
   karma-chai: 0.1.0_chai@4.2.0+karma@4.2.0
@@ -135,6 +137,7 @@ dependencies:
   nyc: 14.1.1
   opn-cli: 4.1.0
   path-browserify: 1.0.0
+  pem-jwk: 2.0.0
   prettier: 1.18.2
   priorityqueuejs: 1.0.0
   process: 0.11.10
@@ -666,6 +669,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-8KmlRxwbKZfjUHFIt3q8TF5S2B+/E5BaAoo/3mgc5h6FJzqxXkCK/VMetO+IRDtwtU6HUvovHMBn+XRj7SV9Qg==
+  /@types/pem-jwk/1.5.0:
+    dev: false
+    resolution:
+      integrity: sha512-xx6+4z5iL2s33dRyS69NAKHEzhCAKSOUSQ/mLrpAr8NCK3UINekUSRVQeX5xSsrJeJIO+NPegFvqBuXmJaj0Bg==
   /@types/priorityqueuejs/1.0.1:
     dev: false
     resolution:
@@ -1349,6 +1356,14 @@ packages:
     dev: false
     resolution:
       integrity: sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==
+  /asn1.js/5.2.0:
+    dependencies:
+      bn.js: 4.11.8
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+    dev: false
+    resolution:
+      integrity: sha512-Q7hnYGGNYbcmGrCPulXfkEw7oW7qjWeM4ZTALmgpuIcZLxyqqKYWxCZg2UBm8bklrnB4m2mGyJPWfoktdORD8A==
   /asn1/0.2.4:
     dependencies:
       safer-buffer: 2.1.2
@@ -5347,6 +5362,14 @@ packages:
     dev: false
     resolution:
       integrity: sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==
+  /jwk-to-pem/2.0.1:
+    dependencies:
+      asn1.js: 4.10.1
+      elliptic: 6.5.0
+      safe-buffer: 5.2.0
+    dev: false
+    resolution:
+      integrity: sha512-KKu0WuDDjqw2FlRFp9/vk9TMO/KvgpZVKzdhhYcNyy5OwE8dw9lOK5OQTQHIJ7m+HioI/4P44sAtVuDrQ8KQfw==
   /jws/3.2.2:
     dependencies:
       jwa: 1.4.1
@@ -7027,6 +7050,15 @@ packages:
       node: '>=0.12'
     resolution:
       integrity: sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==
+  /pem-jwk/2.0.0:
+    dependencies:
+      asn1.js: 5.2.0
+    dev: false
+    engines:
+      node: '>=5.10.0'
+    hasBin: true
+    resolution:
+      integrity: sha512-rFxu7rVoHgQ5H9YsP50dDWf0rHjreVA2z0yPiWr5WdH/UHb29hKtF7h6l8vNd1cbYR1t0QL+JKhW55a2ZV4KtA==
   /pend/1.2.0:
     dev: false
     resolution:
@@ -9697,7 +9729,7 @@ packages:
     dev: false
     name: '@rush-temp/abort-controller'
     resolution:
-      integrity: sha512-2+IDAPkc8w6F7v+Qtv+0QlKup7BbSj9/FJRqus2Fv6lv4Qwfhhl1dII2Ttv0Y3D1jF0IlqOecuzEef9zxLc/jA==
+      integrity: sha512-roO2D9P0Powo1kiA6R5j7l98wJGqy90Sxd8rXDIx34DJoSwoHRs0Y5aL84KiuGgQewmpBktJr6IeoUptngquQg==
       tarball: 'file:projects/abort-controller.tgz'
     version: 0.0.0
   'file:projects/core-amqp.tgz':
@@ -9767,7 +9799,7 @@ packages:
     dev: false
     name: '@rush-temp/core-amqp'
     resolution:
-      integrity: sha512-9LHxNb4QrxyNRXfAf5u1uisfKB2+L3H/fet8fGbe8aotNAfIeVipiftCD8oaATz7qdnG+FXQwLVxXMaz4dI7rg==
+      integrity: sha512-4Eit9uhykBL6/ztuqU7QfXNsa9SMwRnxtKrTuRGFElZKss/cJLbUfhjAUJgE58HaBTJMWUmHXKl5LoSrzo8zJw==
       tarball: 'file:projects/core-amqp.tgz'
     version: 0.0.0
   'file:projects/core-arm.tgz':
@@ -9805,7 +9837,7 @@ packages:
     dev: false
     name: '@rush-temp/core-arm'
     resolution:
-      integrity: sha512-ydCkKGPwdsqk3cZtb5s+PlhnUJNHifGymT1Rh6PjJCVoOOXGTXqZYc4k/EI9DMk/sgI4Vo9cQknrmjG5hRz5dw==
+      integrity: sha512-mfF8QhhPeewWEMJxB1t1a22Zzbm4+gUOpgIkAJJMECPib328vt8cCtZiuStMEl9znoRXlUvCdVZ1ZNr7wyNaDg==
       tarball: 'file:projects/core-arm.tgz'
     version: 0.0.0
   'file:projects/core-asynciterator-polyfill.tgz':
@@ -9824,7 +9856,7 @@ packages:
     dev: false
     name: '@rush-temp/core-asynciterator-polyfill'
     resolution:
-      integrity: sha512-oJErNaXrpCzEEVyYVvv8gcBRnv36c76LBxalfW/l4wlABmUh9u+EuvwI46ig0V3m1bmIluW4S/9O08nO18uyGw==
+      integrity: sha512-77lBXqEBN4nl+SLXGqkc369tAmmBFDGjNJeAJCf0L30gf5MuSb7Akz0PvAzNSvSvmuD4GxcimlVwxxBgV0TGYw==
       tarball: 'file:projects/core-asynciterator-polyfill.tgz'
     version: 0.0.0
   'file:projects/core-auth.tgz':
@@ -9864,7 +9896,7 @@ packages:
     dev: false
     name: '@rush-temp/core-auth'
     resolution:
-      integrity: sha512-D6tMjROHeCf7ijXZIPhewnP5sPK7Aj+k5Na5O5OU629HF7qLBczazjTCnpnnex4X8yvi4X3b82rX/LD2OxZ0dQ==
+      integrity: sha512-jGxK+ySkYGbBbIiATPg9kaQAiJMI1EaSFu/AQ5Dg1RKl86IYAY5qj3Qva7QDvh/Ndj1SJzZipCsrw8nEXt5J5Q==
       tarball: 'file:projects/core-auth.tgz'
     version: 0.0.0
   'file:projects/core-http.tgz':
@@ -9946,7 +9978,7 @@ packages:
     dev: false
     name: '@rush-temp/core-http'
     resolution:
-      integrity: sha512-boYkGbWKFBT8jqs2q2lgsBLUfHRsHzd4utdb9GWM8kR/3Goq7pqiXBSHAnuSaowbK0/QqsCtuZ6bYCnaS1ORQg==
+      integrity: sha512-Z09jOOegm6TVD8hH7kZlxtAoo+f8J2wUPE631WAip3l020Q9pO9xO3/mlOjfX7P1UqYBFSn4+hfYUhelAH0fYw==
       tarball: 'file:projects/core-http.tgz'
     version: 0.0.0
   'file:projects/core-paging.tgz':
@@ -9966,7 +9998,7 @@ packages:
     dev: false
     name: '@rush-temp/core-paging'
     resolution:
-      integrity: sha512-MTsl2eG0FXkUyouQVkSEpgLuG6tNUKE8ckhH8y4B3VUevh/MOS/ghpCqXFRKEAMF7jVfB1s2BSSorGYFuWlcDg==
+      integrity: sha512-F0zLLV7b3kHqXzx+o2KdYceLP0pjOnyFKF0ywvWt63TdH/ga92cV2BL1QbNLQCbRZv7r9DY/vFyngdUYoL4Xwg==
       tarball: 'file:projects/core-paging.tgz'
     version: 0.0.0
   'file:projects/cosmos.tgz':
@@ -10008,7 +10040,7 @@ packages:
     dev: false
     name: '@rush-temp/cosmos'
     resolution:
-      integrity: sha512-rLhtUCCGnwzY3OigHd+TEJ4U0lyBKc2RpjKGMl9koha/aSUchKfm8qHWS+4XO/J2+WldP7yQx6gZY5C+t3cBvQ==
+      integrity: sha512-5oqGeaFo8iGly53D7KKcG7hbMnG9tXZ+JwIkTh4Bofmq7fxOH8w2WosjDoNBaIwiFaMRpL3QkU1FoeuNcbDcog==
       tarball: 'file:projects/cosmos.tgz'
     version: 0.0.0
   'file:projects/event-hubs.tgz':
@@ -10084,7 +10116,7 @@ packages:
     dev: false
     name: '@rush-temp/event-hubs'
     resolution:
-      integrity: sha512-1GJu6YVyxIFLe1hq0W9+is9tGnNt5ExJ6aHDvGGPX+j1zCZnh2x0Lb/fK0VTUcEybCw9D+lLpTd4vXNYphTMww==
+      integrity: sha512-y5i/2v3vT+ll5/MYffjezeWa/J06RraiNw7LG8cfCiFGwUTgl519QsgUD6eBZsWpoGyohvdShVpJQxqf3DeYMA==
       tarball: 'file:projects/event-hubs.tgz'
     version: 0.0.0
   'file:projects/event-processor-host.tgz':
@@ -10142,7 +10174,7 @@ packages:
     dev: false
     name: '@rush-temp/event-processor-host'
     resolution:
-      integrity: sha512-ArbUM9DPleTcwpTC+4K/0fPHmaYl4POCPoGdwyFmHWq6Jci/i2QUwzKVsRt/g1x/N2QmpX9b1ptBbQbCFo5w4A==
+      integrity: sha512-NuSAWALzPLPS7ZhIJ11uj6eR1uUQKFkYIcENyL1QrReG+zT9KoAyauGG+4q2V+lohlwqM8SknQpKhPv1L/I1QQ==
       tarball: 'file:projects/event-processor-host.tgz'
     version: 0.0.0
   'file:projects/identity.tgz':
@@ -10193,7 +10225,7 @@ packages:
     dev: false
     name: '@rush-temp/identity'
     resolution:
-      integrity: sha512-aLe+RHGk7M6wqCmNrblNMYMUtng49pfjo7pctPvnPORnPMD3acKp1+Ld3wQaAjImwPxlq60O1eulxRKAGM/fag==
+      integrity: sha512-mRgBtozQWrBCTuf0gX6CNZOtMN8NNCmmkoQJvSmLpuM7Ck3+5ZT/ObEKsmbqbIvVfujwRGVMl0M49Fh7yp0q0A==
       tarball: 'file:projects/identity.tgz'
     version: 0.0.0
   'file:projects/keyvault-certificates.tgz':
@@ -10222,7 +10254,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-certificates'
     resolution:
-      integrity: sha512-QXnSrcEl4SWcc1wYPRy2BeupDtio52G/miaEJAgse04u88EeU5YoZpQNtZ9l2rzpd/wuJmB2GMkVgUXRnB6zgg==
+      integrity: sha512-GR6tqauh9D2ucn3JyHeWOAGsP8KRh3+TQ3/vZdUFaJDESCIwqrdj90XWGf7BQIlXLdBNTAdq2jFj59CZiS7E7w==
       tarball: 'file:projects/keyvault-certificates.tgz'
     version: 0.0.0
   'file:projects/keyvault-keys.tgz':
@@ -10237,6 +10269,7 @@ packages:
       '@types/nise': 1.4.0
       '@types/nock': 10.0.3
       '@types/node': 8.10.51
+      '@types/pem-jwk': 1.5.0
       '@types/query-string': 6.2.0
       '@typescript-eslint/eslint-plugin': 1.13.0_0b5e999c52a893676e7127c05369c7b6
       '@typescript-eslint/parser': 1.13.0_eslint@5.16.0
@@ -10251,6 +10284,7 @@ packages:
       eslint-plugin-no-only-tests: 2.3.1
       eslint-plugin-promise: 4.2.1
       fs-extra: 8.0.1
+      jwk-to-pem: 2.0.1
       karma: 4.2.0
       karma-chrome-launcher: 2.2.0
       karma-coverage: 1.1.2
@@ -10270,6 +10304,7 @@ packages:
       nise: 1.5.0
       nock: 10.0.6
       nyc: 14.1.1
+      pem-jwk: 2.0.0
       prettier: 1.18.2
       puppeteer: 1.19.0
       query-string: 5.1.1
@@ -10291,7 +10326,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-keys'
     resolution:
-      integrity: sha512-kv1LOiu2pl432/WjarVRLropOwyQrGkOU4tdlA6MiTR9aeysnBosJzkOlScA6HdnBA1rUaoZoILYXQg7x6eS+g==
+      integrity: sha512-lL0MreOFZultbYutR3MeBAtta58vGpJH9hmN4EsjsJ68Ya2q/3p7EFthgLnZSXcTdmxzbcY3Dxlm5no/p5oFWQ==
       tarball: 'file:projects/keyvault-keys.tgz'
     version: 0.0.0
   'file:projects/keyvault-secrets.tgz':
@@ -10360,7 +10395,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-secrets'
     resolution:
-      integrity: sha512-x5m+5BJfn2ssYVl2jzY4YVgvVpgOHP8IQdoFzVG5NlUhYld2DHz4KsEzgYUGdQx5SNud9KLLimjIb4f9FPzSjQ==
+      integrity: sha512-muVffOt1b+OxcqEn+gfub01u6AIUXVwstS3u94SUY2kxW+MunC/9L4eljOu8KI5ugi2MFdXKEOhiycOE/YGjFA==
       tarball: 'file:projects/keyvault-secrets.tgz'
     version: 0.0.0
   'file:projects/service-bus.tgz':
@@ -10438,7 +10473,7 @@ packages:
     dev: false
     name: '@rush-temp/service-bus'
     resolution:
-      integrity: sha512-rkb1doDhx3T0RhPqtdxGi4/jeyG/9Wr5ZfAYDUy+Ck2LzlPuJcbl/S08urt5y51dalNoZHP3n6cjykuKoK0Ylg==
+      integrity: sha512-e/g2I4rDCqgg9Gp0ZA03Y21a6PHVMTRk3Xp4kAzHYilt+mTUncqnTQlwswpXuDgzOzpYJBFMMJaBi3zFsuFG+Q==
       tarball: 'file:projects/service-bus.tgz'
     version: 0.0.0
   'file:projects/storage-blob.tgz':
@@ -10509,7 +10544,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-blob'
     resolution:
-      integrity: sha512-4105iXB3hoaFSq5UdvNfztT1BgIPpS9xe/jnH5QPvhO5vxg7S0zIh7RuKqQE9BjpVpbNYU03ANCVnaymnDmZOQ==
+      integrity: sha512-5956gCM199qB5hFCI26/ziFlrNPx8rRYteZAjvSpTslnNC6GNfjWyX5kBfNrd7RlW9q/JnFszhEa6Ax57pN4Fg==
       tarball: 'file:projects/storage-blob.tgz'
     version: 0.0.0
   'file:projects/storage-file.tgz':
@@ -10580,7 +10615,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-file'
     resolution:
-      integrity: sha512-juOCmmDWgZhQNzudPSlmhETCWJ2pXvezQg1oaVg+MNtkkz8uD2q03kXb7yfYOEM+w9cegsJZUp3jCXt61VkPtQ==
+      integrity: sha512-i8DV36VTmuAWmD2v6AKBgM7vgDcZPMeiw3TQxQidk37eU504zA36fZQgT3KzYTG5/u0hecnkHDycxV+t3tP9Fg==
       tarball: 'file:projects/storage-file.tgz'
     version: 0.0.0
   'file:projects/storage-queue.tgz':
@@ -10650,7 +10685,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-queue'
     resolution:
-      integrity: sha512-s5r16h2hU8MIPBfqhtCgY59+GGhaRwA+vdgVyFzzlWvwd3IE3MDSc/GjVHDXFt0bHes3PU3AQQU6el2IURCm2w==
+      integrity: sha512-yNgr8eHY9Ubp220KB0dE2vIg8J6YtGjZb5BxKewG4a18fp0+YOehMKyeTWNZOEnV1pTZi1XLbmJtjNLvIAloPA==
       tarball: 'file:projects/storage-queue.tgz'
     version: 0.0.0
   'file:projects/template.tgz':
@@ -10702,7 +10737,7 @@ packages:
     dev: false
     name: '@rush-temp/template'
     resolution:
-      integrity: sha512-Lbng6NWBk6fVPMUAdf3pqeb/y6PrAfaBE8BlVthaVo1FsUn1CnIYdCPJylV3q1WReebpXxvvoh7isVsDNvVZ+Q==
+      integrity: sha512-gUaVjaSp9FyoPyox26+zUvUclGrys+BeMUxum0J1KaO5aaX+7+AqWZyxC4ceY7uhjzQpD5Zq5D9TURlpPyufaw==
       tarball: 'file:projects/template.tgz'
     version: 0.0.0
   'file:projects/testhub.tgz':
@@ -10728,9 +10763,10 @@ packages:
     dev: false
     name: '@rush-temp/testhub'
     resolution:
-      integrity: sha512-Lt7NGJIhEbyVoQ1sJ4eUnUg7nGIkdgatRJJMWz18ZVWxKFXPxbBjxPsvIJNirR8QdA3efLv1FhyM4lszfJHcjw==
+      integrity: sha512-ZcS9u3qIhKmJ4XJiak/aUeqAbReZlVhamXs+e/Nl76qLZGa1NjmESPMFUEX1t4I0o4F246aQHX3BfiQDMLzZrw==
       tarball: 'file:projects/testhub.tgz'
     version: 0.0.0
+registry: ''
 specifiers:
   '@azure/abort-controller': 1.0.0-preview.1
   '@azure/amqp-common': 1.0.0-preview.6
@@ -10781,6 +10817,7 @@ specifiers:
   '@types/nise': ^1.4.0
   '@types/nock': ^10.0.1
   '@types/node': ^8.0.0
+  '@types/pem-jwk': ~1.5.0
   '@types/priorityqueuejs': ^1.0.1
   '@types/qs': ~6.5.3
   '@types/query-string': 6.2.0
@@ -10834,6 +10871,7 @@ specifiers:
   inherits: ^2.0.3
   is-buffer: ^2.0.3
   jssha: ^2.3.1
+  jwk-to-pem: ^2.0.1
   jws: ~3.2.2
   karma: ^4.0.1
   karma-chai: ^0.1.0
@@ -10868,6 +10906,7 @@ specifiers:
   nyc: ^14.0.0
   opn-cli: ^4.0.0
   path-browserify: ^1.0.0
+  pem-jwk: ~2.0.0
   prettier: ^1.16.4
   priorityqueuejs: 1.0.0
   process: ^0.11.10

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -72,6 +72,7 @@
     "@azure/core-http": "1.0.0-preview.2",
     "@azure/core-paging": "1.0.0-preview.1",
     "@azure/identity": "1.0.0-preview.2",
+    "pem-jwk": "~2.0.0",
     "tslib": "^1.9.3"
   },
   "devDependencies": {
@@ -84,6 +85,7 @@
     "@types/nise": "^1.4.0",
     "@types/nock": "^10.0.1",
     "@types/node": "^8.0.0",
+    "@types/pem-jwk": "~1.5.0",
     "@types/query-string": "6.2.0",
     "@typescript-eslint/eslint-plugin": "^1.11.0",
     "@typescript-eslint/parser": "^1.11.0",

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -59,11 +59,13 @@ import {
   RequestOptions
 } from "./keysModels";
 import { parseKeyvaultIdentifier as parseKeyvaultEntityIdentifier } from "./core/utils";
+import { CryptographyClient } from "./CryptographyClient"
 
 export {
   CreateEcKeyOptions,
   CreateRsaKeyOptions,
   CreateKeyOptions,
+  CryptographyClient,
   DeletedKey,
   DeletionRecoveryLevel,
   GetKeyOptions,

--- a/sdk/keyvault/keyvault-keys/tests/crypto.test.ts
+++ b/sdk/keyvault/keyvault-keys/tests/crypto.test.ts
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import * as assert from "assert";
+import { ClientSecretCredential } from "@azure/identity";
+import { CryptographyClient, Key, KeysClient } from "../src";
+import { authenticate } from "./utils/testAuthentication";
+import TestClient from "./utils/testClient";
+import { str2ab, ab2str } from "./utils/crypto"
+
+describe.only("CryptographyClient", () => {
+  let client: KeysClient;
+  let testClient: TestClient;
+  let cryptoClient: CryptographyClient;
+  let recorder: any;
+  let credential: ClientSecretCredential;
+  let keyName: string;
+  let key: Key;
+  let keyVaultUrl: string;
+  let keyUrl: string;
+
+  before(async function() {
+    const authentication = await authenticate(this);
+    client = authentication.client;
+    recorder = authentication.recorder;
+    testClient = authentication.testClient;
+    credential = authentication.credential;
+    keyName = testClient.formatName("CryptographyClientTestKey");
+    key = await client.createKey(keyName, "RSA");
+    keyVaultUrl = key.vaultUrl;
+    keyUrl = key.keyMaterial!.kid as string;
+    cryptoClient = new CryptographyClient(keyVaultUrl, keyUrl, credential);
+  });
+
+  after(async function() {
+    await testClient.flushKey(keyName);
+    recorder.stop();
+  });
+
+  // The tests follow
+
+  it("getKey from key URL", async function() {
+    const cryptoClient = new CryptographyClient(keyVaultUrl, keyUrl, credential);
+    const getKeyResult = await cryptoClient.getKey();
+    assert.equal(getKeyResult.kid, keyUrl)
+  });
+
+  it.skip("getKey from JWK key");
+
+  // TODO: How to make a key that can't be read locally?
+  // I did run this test before adding local support.
+  it.skip("encrypt & decrypt remotely with RSA-OAEP", async function() {
+    const cryptoClient = new CryptographyClient(keyVaultUrl, keyUrl, credential);
+    const text = this.test!.title;
+    const bufferText = str2ab(text);
+    const encrypted = await cryptoClient.encrypt(bufferText, "RSA-OAEP");
+    const decrypted = await cryptoClient.decrypt(encrypted, "RSA-OAEP");
+    const decryptedText = ab2str(decrypted);
+    assert.equal(text, decryptedText);
+  });
+ 
+  it("encrypt & decrypt locally with RSA-OAEP", async function() {
+    const text = this.test!.title;
+    const bufferText = str2ab(text);
+    const encrypted = await cryptoClient.encrypt(bufferText, "RSA-OAEP");
+    const decrypted = await cryptoClient.decrypt(encrypted, "RSA-OAEP");
+    const decryptedText = ab2str(decrypted);
+    assert.equal(text, decryptedText);
+  });
+});

--- a/sdk/keyvault/keyvault-keys/tests/utils/crypto.ts
+++ b/sdk/keyvault/keyvault-keys/tests/utils/crypto.ts
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { isNode } from "./recorder";
+
+export function str2ab(str: string): Uint8Array {
+  if (isNode) {
+    return new Uint8Array(Buffer.from(str));
+  } else {
+    const bytes = new Uint8Array(str.length);
+    for (let i = 0; i < str.length; i++) {
+      bytes[i] = str.charCodeAt(i);
+    }
+    return bytes;
+  }
+}
+
+export function ab2str(ab: Uint8Array): string {
+  if (isNode) {
+    return Buffer.from(ab).toString("utf-8");
+  } else {
+    const decoder = new TextDecoder("utf-8");
+    return decoder.decode(ab);
+  }
+}

--- a/sdk/keyvault/keyvault-keys/tests/utils/testAuthentication.ts
+++ b/sdk/keyvault/keyvault-keys/tests/utils/testAuthentication.ts
@@ -32,5 +32,5 @@ export async function authenticate(that: any): Promise<any> {
   const client = new KeysClient(keyVaultUrl, credential);
   const testClient = new TestClient(client);
 
-  return { recorder, client, testClient, keySuffix };
+  return { recorder, client, credential, testClient, keySuffix };
 }


### PR DESCRIPTION
Here I'm trying to expand into encrypt and decrypt to work both with the
remote service and the local NodeJS API. Not only that, but I'm also
trying to make it work as part of our build bundle.

I was successful to call encrypt and decrypt with the live services,
but once I added the code related to Node crypto, I started finding
problems. I was not successful to build it with the local node
implementation (so I also wasn't able to finish testing it). The last
error I'm getting is that apparently "crypto.constants" does not exist
in @types/node

I had this error in my local tests. I was able to fix it by upgrading
@types/node to ^12.6.1. We're currenlty using 8.0.0. Would it be ok to
upgrade this package?